### PR TITLE
Improvement #116/117/118/119 Remove Soomla script

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Store/Config/StoreSettings.cs
+++ b/Soomla/Assets/Plugins/Soomla/Store/Config/StoreSettings.cs
@@ -42,6 +42,12 @@ namespace Soomla.Store
 		static StoreSettings()
 		{
 			SoomlaEditorScript.addSettings(instance);
+
+			List<string> additionalDependFiles = new List<string>(); //Add files that not tracked in file_list
+			additionalDependFiles.Add("Assets/Plugins/Android/Soomla/libs/AndroidStoreAmazon.jar");
+			additionalDependFiles.Add("Assets/Plugins/Android/Soomla/libs/in-app-purchasing-2.0.1.jar");
+			additionalDependFiles.Add("Assets/Plugins/Android/Soomla/libs/AndroidStoreGooglePlay.jar");
+			SoomlaEditorScript.addFileList("Store", "Assets/Soomla/store_file_list", additionalDependFiles.ToArray());
 		}
 
 		bool showAndroidSettings = (EditorUserBuildSettings.activeBuildTarget == BuildTarget.Android);
@@ -87,7 +93,7 @@ namespace Soomla.Store
 		}
 
 		public void OnInfoGUI() {
-			SoomlaEditorScript.SelectableLabelField(frameworkVersion, currentModuleVersion);
+			SoomlaEditorScript.RemoveSoomlaModuleButton(frameworkVersion, currentModuleVersion, "Store");
 			SoomlaEditorScript.LatestVersionField ("unity3d-store", currentModuleVersion, "New Store version available!", "http://library.soom.la/fetch/unity3d-store/latest?cf=unity");
 			EditorGUILayout.Space();
 		}


### PR DESCRIPTION
116 - Add exception to remove scripts in unity4 for that case
117 - Add ability to remove a single SOOMLA module from unity
118 - Make Remove SOOMLA script also remove Soomla folders
119 - Make Remove SOOMLA script work well with IAB and social providers
